### PR TITLE
feat: identify album by title and album artist

### DIFF
--- a/qm-music-parent/qm-music-app/src/main/resources/db/migration/V2.4__album_unique_key.sql
+++ b/qm-music-parent/qm-music-app/src/main/resources/db/migration/V2.4__album_unique_key.sql
@@ -1,0 +1,45 @@
+-- 专辑唯一键由 title 调整为 (title, artist_id)，支持不同歌手的同名专辑
+-- SQLite 无法直接修改列级约束，需要重建表
+CREATE TABLE album_new (
+                       id INTEGER PRIMARY KEY,
+                       title VARCHAR(255) NOT NULL,
+                       artist_id INTEGER NOT NULL DEFAULT 2026,
+                       release_year CHAR(4),
+                       genre VARCHAR(50),
+                       song_count INTEGER NOT NULL,
+                       duration INTEGER NOT NULL,
+                       artist_name VARCHAR(128),
+                       cover_art VARCHAR(128),
+                       gmt_create DATETIME DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW','localtime')),
+                       gmt_modify DATETIME DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW','localtime')),
+                       first_letter_title VARCHAR(1),
+                       first_letter_artist_name VARCHAR(1)
+);
+
+-- 旧约束保证 title 全局唯一，(title, artist_id) 必然不冲突；COALESCE 防御手工改库产生的 NULL
+INSERT INTO album_new (id, title, artist_id, release_year, genre, song_count, duration,
+                       artist_name, cover_art, gmt_create, gmt_modify,
+                       first_letter_title, first_letter_artist_name)
+SELECT id, title, COALESCE(artist_id, 2026), release_year, genre, song_count, duration,
+       artist_name, cover_art, gmt_create, gmt_modify,
+       first_letter_title, first_letter_artist_name
+FROM album;
+
+DROP TABLE album;
+
+ALTER TABLE album_new RENAME TO album;
+
+CREATE UNIQUE INDEX uk_album_title_artist ON album(title, artist_id);
+CREATE INDEX idx_album_artist ON album(artist_id);
+CREATE INDEX idx_album_genre_year ON album(genre, release_year);
+CREATE INDEX idx_album_release_year ON album(release_year);
+CREATE INDEX idx_album_gmt_create ON album(gmt_create);
+
+-- 触发器与 V1.2__change_trigger.sql 统一的实现保持一致（带毫秒的本地时间字符串）
+CREATE TRIGGER IF NOT EXISTS update_album_gmt_modify
+    AFTER UPDATE ON album
+BEGIN
+    UPDATE album
+    SET gmt_modify = STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW','localtime')
+    WHERE id = NEW.id;
+END;

--- a/qm-music-parent/qm-music-core/src/main/java/com/github/chenqimiao/qmmusic/core/service/complex/impl/SubsonicMediaFetcherServiceImpl.java
+++ b/qm-music-parent/qm-music-core/src/main/java/com/github/chenqimiao/qmmusic/core/service/complex/impl/SubsonicMediaFetcherServiceImpl.java
@@ -180,10 +180,10 @@ public class SubsonicMediaFetcherServiceImpl implements MediaFetcherService {
         String delimiterRegx = CommonConstants.ARTIST_NAME_DELIMITER_REGX;
         MusicAlbumMeta musicAlbumMeta = musicMeta.getMusicAlbumMeta();
 
-        List<ArtistDO> songArtists = new ArrayList<>();
-        List<ArtistDO> albumArtists = new ArrayList<>();
+        final List<ArtistDO> songArtists = new ArrayList<>();
+        final List<ArtistDO> albumArtists = new ArrayList<>();
         if (StringUtils.isNotBlank(musicMeta.getArtist())) {
-            songArtists = Arrays.stream(musicMeta.getArtist().split(delimiterRegx))
+            List<ArtistDO> toBeSavedSongArtists = Arrays.stream(musicMeta.getArtist().split(delimiterRegx))
                     .filter(StringUtils::isNotBlank)
                     .map(String::trim)
                     .distinct()
@@ -195,14 +195,14 @@ public class SubsonicMediaFetcherServiceImpl implements MediaFetcherService {
                         return artistDO;
                     }).collect(Collectors.toList());
 
-            songArtists = artistRepository.saveAndReturn(songArtists);
+            songArtists.addAll(artistRepository.saveAndReturn(toBeSavedSongArtists));
         }
         if (CollectionUtils.isEmpty(songArtists)) {
             songArtists.add(unknownArtist);
         }
 
         if (StringUtils.isNotBlank(musicAlbumMeta.getAlbumArtist())) {
-            albumArtists = Arrays.stream(musicAlbumMeta.getAlbumArtist().split(delimiterRegx))
+            List<ArtistDO> toBeSavedAlbumArtists = Arrays.stream(musicAlbumMeta.getAlbumArtist().split(delimiterRegx))
                     .filter(StringUtils::isNotBlank)
                     .map(String::trim)
                     .distinct()
@@ -214,7 +214,7 @@ public class SubsonicMediaFetcherServiceImpl implements MediaFetcherService {
                         return artistDO;
                     }).collect(Collectors.toList());
 
-            albumArtists = artistRepository.saveAndReturn(albumArtists);
+            albumArtists.addAll(artistRepository.saveAndReturn(toBeSavedAlbumArtists));
 
         }
 
@@ -230,14 +230,14 @@ public class SubsonicMediaFetcherServiceImpl implements MediaFetcherService {
 
         AlbumDO albumDO = null;
         if (StringUtils.isNotBlank(musicAlbumMeta.getAlbum())) {
-             albumDO = albumRepository.queryByUniqueKey(musicAlbumMeta.getAlbum());
+            ArtistDO albumArtist = albumArtists.getFirst();
+            albumDO = albumRepository.queryByUniqueKey(musicAlbumMeta.getAlbum(), albumArtist.getId());
 
             if (albumDO == null) {
                 albumDO = new AlbumDO();
                 albumDO.setId(sequence.nextId());
                 albumDO.setTitle(musicAlbumMeta.getAlbum());
-                ArtistDO albumArtist = CollectionUtils.isNotEmpty(albumArtists)? albumArtists.getFirst(): null;
-                albumDO.setArtist_id(Optional.ofNullable(albumArtist).map(ArtistDO::getId).orElse(null));
+                albumDO.setArtist_id(albumArtist.getId());
                 String releaseYear = StringUtils.isNotBlank(musicAlbumMeta.getYear()) ? musicAlbumMeta.getYear()
                         : musicAlbumMeta.getOriginalYear();
                 albumDO.setRelease_year(MusicFileReader.beautifyReleaseYear(releaseYear));
@@ -245,8 +245,8 @@ public class SubsonicMediaFetcherServiceImpl implements MediaFetcherService {
                 String trackTotal = musicAlbumMeta.getTrackTotal();
                 albumDO.setSong_count(NumberUtils.toInt(trackTotal, NumberUtils.INTEGER_ZERO));
                 albumDO.setDuration(2025); // QM birth year
-                albumDO.setArtist_name(Optional.ofNullable(albumArtist).map(ArtistDO::getName).orElse(null));
-                albumDO.setFirst_letter_artist_name(Optional.ofNullable(albumArtist).map(ArtistDO::getFirst_letter).orElse(CommonConstants.UN_KNOWN_FIRST_LETTER));
+                albumDO.setArtist_name(albumArtist.getName());
+                albumDO.setFirst_letter_artist_name(Optional.ofNullable(albumArtist.getFirst_letter()).orElse(CommonConstants.UN_KNOWN_FIRST_LETTER));
                 albumDO.setFirst_letter_title(FirstLetterUtil.getFirstLetter(musicAlbumMeta.getAlbum()));
                 albumDO = albumRepository.saveAndReturn(albumDO);
             }

--- a/qm-music-parent/qm-music-dao/src/main/java/com/github/chenqimiao/qmmusic/dao/repository/AlbumRepository.java
+++ b/qm-music-parent/qm-music-dao/src/main/java/com/github/chenqimiao/qmmusic/dao/repository/AlbumRepository.java
@@ -83,13 +83,13 @@ public class AlbumRepository {
         return namedParameterJdbcTemplate.query(sql, params, ROW_MAPPER_ALBUM_ITEM);
     }
 
-    public AlbumDO queryByUniqueKey(String albumName) {
+    public AlbumDO queryByUniqueKey(String albumName, Long artistId) {
         String sql = """
-                        select * from album where `title` = ?
+                        select * from album where `title` = ? and `artist_id` = ?
                      """;
         try {
             return jdbcTemplate.queryForObject(sql, ROW_MAPPER_ALBUM_ITEM,
-                    albumName);
+                    albumName, artistId);
         }catch (EmptyResultDataAccessException e){
             return null;
         }
@@ -138,7 +138,7 @@ public class AlbumRepository {
 
         this.save(albumDO);
 
-        return this.queryByUniqueKey(albumDO.getTitle());
+        return this.queryByUniqueKey(albumDO.getTitle(), albumDO.getArtist_id());
     }
 
     public List<Long> queryAllAlbumId() {

--- a/qm-music-parent/qm-music-dao/src/main/java/com/github/chenqimiao/qmmusic/dao/repository/ArtistRepository.java
+++ b/qm-music-parent/qm-music-dao/src/main/java/com/github/chenqimiao/qmmusic/dao/repository/ArtistRepository.java
@@ -17,6 +17,9 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * @author Qimiao Chen
@@ -125,7 +128,11 @@ public class ArtistRepository {
         }
         this.save(artistList);
         List<String> names = artistList.stream().map(ArtistDO::getName).toList();
-        return this.queryByUniqueKeys(names);
+        // in 查询的返回顺序是索引序，需按入参（标签书写序）重排，首位即主艺术家
+        Map<String, ArtistDO> artistMap = this.queryByUniqueKeys(names).stream()
+                .collect(Collectors.toMap(ArtistDO::getName, Function.identity(), (a, b) -> a));
+        return names.stream().map(artistMap::get).filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
     public List<Long> findAllArtistIds() {


### PR DESCRIPTION
Albums with the same title from different artists were merged into one because the album unique key was title only. Change the key to (title, artist_id):

- V2.4 migration rebuilds the album table with UNIQUE(title, artist_id) and artist_id NOT NULL DEFAULT 2026 (Unknown Artist)
- AlbumRepository.queryByUniqueKey/saveAndReturn query by both fields
- Scanner resolves the album artist (ALBUMARTIST -> ARTIST -> Unknown) and passes its id when looking up or creating albums
- ArtistRepository.saveAndReturn keeps the tag order of artists so the first artist is the primary one from the tag, not DB index order
- Keep songArtists/albumArtists final and use addAll so the fallback never operates on an immutable list

Existing data is migrated as-is; previously merged albums are not split retroactively.