### PR TITLE
feat: auto redirect to login page when session is invalid

### DIFF
--- a/qm-music-parent/qm-music-app/src/main/resources/static/index.html
+++ b/qm-music-parent/qm-music-app/src/main/resources/static/index.html
@@ -460,6 +460,23 @@
     </div>
 </div>
 <script>
+    // 会话失效（如修改密码后旧 token 失效）时，自动清理本地登录态并跳转登录页
+    let redirectingToLogin = false;
+    axios.interceptors.response.use(response => {
+        const error = response.data?.['subsonic-response']?.error;
+        if (error && String(error.code) === '40' && !redirectingToLogin) {
+            redirectingToLogin = true;
+            ['u', 'v', 'c', 't', 's', 'f'].forEach(key => localStorage.removeItem(key));
+            alert('登录状态已失效，请重新登录');
+            window.location.href = 'login.html';
+        }
+        if (redirectingToLogin) {
+            // 页面即将跳转，挂起后续响应，避免调用方 catch 再次弹窗
+            return new Promise(() => {});
+        }
+        return response;
+    });
+
     const { createApp } = Vue;
     createApp({
         data() {


### PR DESCRIPTION
Add a global axios response interceptor in index.html: when any /rest request returns subsonic error code 40 (e.g. old token invalidated by a password change), clear local credentials and redirect to login.html.